### PR TITLE
Fixed bad_alloc issue and various valgrind warnings

### DIFF
--- a/cpp/Declaration.h
+++ b/cpp/Declaration.h
@@ -64,7 +64,7 @@ public:
     const SourcePos sourcePos;
 
     Declaration(const std::string &name, std::shared_ptr<BSVType> bsvtype)
-            : package(), name(name), uniqueName(genUniqueName(string(), name, LocalBindingType)), bsvtype(bsvtype), bindingType(LocalBindingType) {
+            : package(), name(name), uniqueName(genUniqueName(string(), name, LocalBindingType)), bsvtype(bsvtype), bindingType(LocalBindingType), parent(), sourcePos(), numericTypeParamVector() {
         if (bsvtype) {
             for (int i = 0; i < bsvtype->params.size(); i++) {
                 numericTypeParamVector.push_back(bsvtype->params[i]->isNumeric());
@@ -73,7 +73,7 @@ public:
     };
 
     Declaration(const std::string &package, const std::string &name, std::shared_ptr<BSVType> bsvtype, const BindingType bt = LocalBindingType, SourcePos sourcePos = SourcePos())
-    : package(package), name(name), uniqueName(genUniqueName(package, name, bt)), bsvtype(bsvtype), bindingType(bt), sourcePos(sourcePos) {
+    : package(package), name(name), uniqueName(genUniqueName(package, name, bt)), bsvtype(bsvtype), bindingType(bt), parent(), sourcePos(sourcePos), numericTypeParamVector() {
         if (bsvtype) {
             for (int i = 0; i < bsvtype->params.size(); i++) {
                 numericTypeParamVector.push_back(bsvtype->params[i]->isNumeric());
@@ -178,8 +178,8 @@ class UnionDeclaration : public Declaration {
 public:
     std::vector<std::shared_ptr<Declaration> > members;
 
-    UnionDeclaration(std::string name, std::shared_ptr<BSVType> bsvtype, SourcePos sourcePos)
-            : Declaration(package, name, bsvtype, GlobalBindingType, sourcePos) {};
+    UnionDeclaration(const std::string &package, std::string name, std::shared_ptr<BSVType> bsvtype, SourcePos sourcePos)
+            : Declaration(package, name, bsvtype, GlobalBindingType, sourcePos), members() {};
     shared_ptr<UnionDeclaration> unionDeclaration() override { return static_pointer_cast<UnionDeclaration, Declaration>(shared_from_this()); }
     shared_ptr<Declaration> lookupMember(const string &memberName);
 };

--- a/cpp/TypeChecker.cpp
+++ b/cpp/TypeChecker.cpp
@@ -714,7 +714,7 @@ void TypeChecker::addDeclaration(BSVParser::TypedefsynonymContext *synonymdef) {
 void TypeChecker::addDeclaration(BSVParser::TypedeftaggedunionContext *uniondef) {
     shared_ptr<BSVType> typedeftype(bsvtype(uniondef->typedeftype()));
     string name = typedeftype->name;
-    shared_ptr<UnionDeclaration> unionDecl = make_shared<UnionDeclaration>(name, typedeftype, sourcePos(uniondef));
+    shared_ptr<UnionDeclaration> unionDecl = make_shared<UnionDeclaration>(currentContext->packageName, name, typedeftype, sourcePos(uniondef));
     currentContext->logstream << "add declaration typedef union " << name << endl;
     for (int i = 0; uniondef->unionmember(i); i++) {
         shared_ptr<Declaration> subdecl = visit(uniondef->unionmember(i));

--- a/cpp/main.cpp
+++ b/cpp/main.cpp
@@ -142,6 +142,7 @@ int main(int argc, char *const argv[]) {
 
     int ch;
     BSVOptions options;
+    options.dumptree = dumptree;
     options.opt_type_check = 1; // mandatory -- used when generating AST
     options.opt_ast = 1;
     options.opt_kami = 0;


### PR DESCRIPTION
I still get an issue with a bad_alloc exception when running bsv-parser compiled from the head of master. I fixed this with the attached change to UnionDeclaration. The other changes get rid of the remaining errors seen when running bsv-parser with valgrind.